### PR TITLE
Fix bug that generated toc links weirdly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -490,6 +490,8 @@ fn write_readme_content(file: &mut File, in_path: &Path, raw_path: &Path)
             for line in readme.split('\n') {
                 if line.starts_with("###") {
                     let line = line.get(4..).unwrap();
+                    // trim the line to remove the trailing whitespace
+                    let line = line.trim();
                     file.write_all(
                         format!(
                             r##"       <a href="#{}">{}</a>
@@ -500,6 +502,7 @@ fn write_readme_content(file: &mut File, in_path: &Path, raw_path: &Path)
                     )?;
                 } else if line.starts_with("##") {
                     let line = line.get(3..).unwrap();
+                    let line = line.trim();
                     file.write_all(
                         format!(
                             r##"    <a href="#{}">{}</a>
@@ -510,6 +513,7 @@ fn write_readme_content(file: &mut File, in_path: &Path, raw_path: &Path)
                     )?;
                 } else if line.starts_with("#") {
                     let line = line.get(2..).unwrap();
+                    let line = line.trim();
                     file.write_all(
                         format!(
                             r##"<a href="#{}">{}</a>


### PR DESCRIPTION
Hi, I came across your site [emile.space](emile.space) and really liked it and wanted to create a similar site of my own, so I dug deep and found your site generate vokobe and tried generating your website locally, But it had a weird bug, the links that were being created from toc were also appending new line character in the text like this 
![Screenshot (2)](https://user-images.githubusercontent.com/25881429/209566131-e656f8c6-5ac5-4a87-978c-dde5dca9dd7f.png)

So i looked in the rust file and made some changes now it works like the way it is supposed to 
![Screenshot (3)](https://user-images.githubusercontent.com/25881429/209566174-d34a4eb0-e220-47ba-8bb4-995ebc98ea24.png)


idk if this was a bug or it was just behaving differently on my machine only. 
